### PR TITLE
Remove ref to branch/release-4.2 for Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 # Installation
 
-For OpenShift 4.1 and 4.2 use branch `release-4.2`. Do not use `master` branch. 
-
 ```
 $ git clone https://github.com/openshift-psap/special-resource-operator
 $ cd special-resource-operator
-$ git checkout release-4.2
 $ PULLPOLICY=Always make deploy
 ```
 


### PR DESCRIPTION
Just an update to the Installation section of the README to remove the reference to using the branch `release-4.2` for deployment since it's broken according to [Bug 1769174](https://bugzilla.redhat.com/show_bug.cgi?id=1769174)