### PR TITLE
Adding monitoring support for SRO

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,4 +1,3 @@
-
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
@@ -18,11 +17,11 @@ namePrefix: special-resource-operator-
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-  # Protect the /metrics endpoint by putting it behind auth.
-  # If you want your controller-manager to expose the /metrics
-  # endpoint w/o any authn/z, please comment the following line.
+# Protect the /metrics endpoint by putting it behind auth.
+# If you want your controller-manager to expose the /metrics
+# endpoint w/o any authn/z, please comment the following line.
 patchesStrategicMerge:
-- manager_auth_proxy_patch.yaml
+  - manager_auth_proxy_patch.yaml
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
@@ -37,7 +36,8 @@ patchesStrategicMerge:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../crd
-- ../rbac
-- ../manager
+  - ../crd
+  - ../rbac
+  - ../manager
+  - ../prometheus
 namespace: openshift-sro

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -23,8 +23,6 @@ spec:
             - containerPort: 8443
               name: https
           volumeMounts:
-            - name: special-resource-operator-trusted-ca
-              mountPath: /etc/secrets/ca
             - name: special-resource-operator-tls
               mountPath: /etc/secrets
         - name: manager

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -1,4 +1,4 @@
-# This patch inject a sidecar container which is a HTTP proxy for the 
+# This patch inject a sidecar container which is a HTTP proxy for the
 # controller manager, it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
 apiVersion: apps/v1
 kind: Deployment
@@ -9,17 +9,25 @@ spec:
   template:
     spec:
       containers:
-      - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
-        args:
-        - "--secure-listen-address=0.0.0.0:8443"
-        - "--upstream=http://127.0.0.1:8080/"
-        - "--logtostderr=true"
-        - "--v=10"
-        ports:
-        - containerPort: 8443
-          name: https
-      - name: manager
-        args:
-        - "--metrics-addr=127.0.0.1:8080"
-        - "--enable-leader-election"
+        - name: kube-rbac-proxy
+          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+          args:
+            - "--secure-listen-address=0.0.0.0:8443"
+            - "--upstream=http://127.0.0.1:8080/"
+            - "--logtostderr=true"
+            - "--v=10"
+            - "--tls-cert-file=/etc/secrets/tls.crt"
+            - "--tls-private-key-file=/etc/secrets/tls.key"
+            - "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+          ports:
+            - containerPort: 8443
+              name: https
+          volumeMounts:
+            - name: special-resource-operator-trusted-ca
+              mountPath: /etc/secrets/ca
+            - name: special-resource-operator-tls
+              mountPath: /etc/secrets
+        - name: manager
+          args:
+            - "--metrics-addr=127.0.0.1:8080"
+            - "--enable-leader-election"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/openshift-psap/special-resource-operator
-  newTag: simple-kmod-v2
+  newTag: monitoring

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,9 +1,10 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    control-plane: controller-manager
-  name: system
+# PLACEHODLER UNTIL KUSTOMIZE CAN UPDATE NAMESPACES
+#apiVersion: v1
+#kind: Namespace
+#metadata:
+#  labels:
+#    control-plane: controller-manager
+#  name: system
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -23,25 +24,32 @@ spec:
         control-plane: controller-manager
     spec:
       containers:
-      - imagePullPolicy: Always # TODO 
-        env:
-          - name: OPERATOR_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-        command:
-        - /manager
-        args:
-        - "--enable-leader-election"
-        - "--zap-encoder=console"
-        - "--zap-log-level=debug"
-        image: controller:latest
-        name: manager
-#        resources:
-#          limits:
-#            cpu: 200m
-#            memory: 60Mi
-#          requests:
-#            cpu: 200m
-#            memory: 40Mi
+        - imagePullPolicy: Always # TODO
+          env:
+            - name: OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /manager
+          args:
+            - "--enable-leader-election"
+            - "--zap-encoder=console"
+            - "--zap-log-level=debug"
+          image: controller:latest
+          name: manager
+          resources:
+            limits:
+              cpu: 200m
+              memory: 100Mi
+            requests:
+              cpu: 200m
+              memory: 100Mi
+      volumes:
+        - name: special-resource-operator-tls
+          secret:
+            secretName: special-resource-operator-tls
+        - name: special-resource-operator-trusted-ca
+          configMap:
+            name: special-resource-operator-trusted-ca
       terminationGracePeriodSeconds: 10

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -49,7 +49,4 @@ spec:
         - name: special-resource-operator-tls
           secret:
             secretName: special-resource-operator-tls
-        - name: special-resource-operator-trusted-ca
-          configMap:
-            name: special-resource-operator-trusted-ca
       terminationGracePeriodSeconds: 10

--- a/config/namespace/namespace.yaml
+++ b/config/namespace/namespace.yaml
@@ -3,4 +3,7 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
+    openshift.io/cluster-monitoring: "true"
   name: openshift-sro
+---
+

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -1,4 +1,3 @@
-
 # Prometheus Monitor Service (Metrics)
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -9,8 +8,57 @@ metadata:
   namespace: system
 spec:
   endpoints:
-    - path: /metrics
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      path: /metrics
       port: https
+      scheme: https
+      interval: 30s
+      tlsConfig:
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        serverName: special-resource-operator-controller-manager-metrics-service.openshift-sro.svc
+  namespaceSelector:
+    matchNames:
+      - openshift-sro
   selector:
     matchLabels:
       control-plane: controller-manager
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    #include.release.openshift.io/ibm-cloud-managed: "true"
+    #include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/create-only: "true"
+    service.beta.openshift.io/inject-cabundle: "true"
+  name: trusted-ca
+  namespace: openshift-sro

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -51,14 +51,3 @@ subjects:
   - kind: ServiceAccount
     name: prometheus-k8s
     namespace: openshift-monitoring
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  annotations:
-    #include.release.openshift.io/ibm-cloud-managed: "true"
-    #include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/create-only: "true"
-    service.beta.openshift.io/inject-cabundle: "true"
-  name: trusted-ca
-  namespace: openshift-sro

--- a/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,7 +1,7 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader
 rules:
-- nonResourceURLs: ["/metrics"]
-  verbs: ["get"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -1,14 +1,16 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: special-resource-operator-tls
   labels:
     control-plane: controller-manager
   name: controller-manager-metrics-service
   namespace: system
 spec:
   ports:
-  - name: https
-    port: 8443
-    targetPort: https
+    - name: https
+      port: 8443
+      targetPort: https
   selector:
     control-plane: controller-manager


### PR DESCRIPTION
This is not well documented how to use monitoring and TLS with kube-rbac-proxy. Most of the steps in the monitoring guide are working but without kube-rbac-proxy. This setup here works also with kube-rbac-proxy. 

@dagrayvid PTAL we can scrape but we need some metrics created. 