### PR TITLE
Add metrics to SRO

### DIFF
--- a/controllers/metrics.go
+++ b/controllers/metrics.go
@@ -1,0 +1,43 @@
+package controllers
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// When adding metric names, see https://prometheus.io/docs/practices/naming/#metric-names
+const (
+    specialResourcesCreatedQuery = "sro_managed_resources_total"
+	completedStatesQuery = "sro_states_completed_info"
+
+)
+
+var (
+	//#TODO set the metric
+	specialResourcesCreated = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: specialResourcesCreatedQuery,
+			Help: "Number of specialresources created",
+		},
+	)
+	completedStates = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: completedStatesQuery,
+			Help: "For a given specialresource and state, 1 if the state is completed, 0 if it is not.",
+		},
+		[]string{"specialresource", "state"},
+	)
+)
+
+func setCompletedState(specialResource string, state string, value int) {
+	completedStates.WithLabelValues(specialResource, state).Set(float64(value))
+}
+
+func init() {
+	// Register custom metrics with the global prometheus registry
+	metrics.Registry.MustRegister(
+		specialResourcesCreated,
+		completedStates,
+	)
+
+}

--- a/controllers/metrics.go
+++ b/controllers/metrics.go
@@ -7,9 +7,9 @@ import (
 
 // When adding metric names, see https://prometheus.io/docs/practices/naming/#metric-names
 const (
-    specialResourcesCreatedQuery = "sro_managed_resources_total"
+	specialResourcesCreatedQuery = "sro_managed_resources_total"
 	completedStatesQuery = "sro_states_completed_info"
-
+	
 )
 
 var (

--- a/controllers/metrics.go
+++ b/controllers/metrics.go
@@ -8,8 +8,7 @@ import (
 // When adding metric names, see https://prometheus.io/docs/practices/naming/#metric-names
 const (
 	specialResourcesCreatedQuery = "sro_managed_resources_total"
-	completedStatesQuery = "sro_states_completed_info"
-	
+	completedStatesQuery         = "sro_states_completed_info"
 )
 
 var (
@@ -31,6 +30,10 @@ var (
 
 func setCompletedState(specialResource string, state string, value int) {
 	completedStates.WithLabelValues(specialResource, state).Set(float64(value))
+}
+
+func setSpecialResourcesCreated(value int) {
+	specialResourcesCreated.Set(float64(value))
 }
 
 func init() {

--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -254,8 +254,10 @@ func ReconcileHardwareStates(r *SpecialResourceReconciler, config unstructured.U
 		log.Info("Executing", "State", state)
 		namespacedYAML := []byte(manifests[state].(string))
 		if err := createFromYAML(namespacedYAML, r, r.specialresource.Spec.Namespace); err != nil {
+			setCompletedState(r.specialresource.Name, state, 0)
 			return errs.Wrap(err, "Failed to create resources")
 		}
+		setCompletedState(r.specialresource.Name, state, 1)
 	}
 
 	return nil

--- a/controllers/specialresource.go
+++ b/controllers/specialresource.go
@@ -56,7 +56,7 @@ func ReconcilerSpecialResources(r *SpecialResourceReconciler, req ctrl.Request) 
 
 	specialresources := &srov1beta1.SpecialResourceList{}
 
-    // set specialResourcesCreated metric to the number of specialresources
+	// set specialResourcesCreated metric to the number of specialresources
 
 	opts := []client.ListOption{}
 	err := r.List(context.TODO(), specialresources, opts...)

--- a/controllers/specialresource.go
+++ b/controllers/specialresource.go
@@ -56,8 +56,6 @@ func ReconcilerSpecialResources(r *SpecialResourceReconciler, req ctrl.Request) 
 
 	specialresources := &srov1beta1.SpecialResourceList{}
 
-	// set specialResourcesCreated metric to the number of specialresources
-
 	opts := []client.ListOption{}
 	err := r.List(context.TODO(), specialresources, opts...)
 	if err != nil {
@@ -70,6 +68,9 @@ func ReconcilerSpecialResources(r *SpecialResourceReconciler, req ctrl.Request) 
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
+
+	// set specialResourcesCreated metric to the number of specialresources
+	setSpecialResourcesCreated(len(specialresources.Items))
 
 	for _, r.parent = range specialresources.Items {
 

--- a/controllers/specialresource.go
+++ b/controllers/specialresource.go
@@ -55,6 +55,9 @@ func ReconcilerSpecialResources(r *SpecialResourceReconciler, req ctrl.Request) 
 	r.Log.Info("Reconciling SpecialResource(s) in all Namespaces")
 
 	specialresources := &srov1beta1.SpecialResourceList{}
+
+    // set specialResourcesCreated metric to the number of specialresources
+
 	opts := []client.ListOption{}
 	err := r.List(context.TODO(), specialresources, opts...)
 	if err != nil {


### PR DESCRIPTION
Add a controllers/metrics.go file which will initialize few metrics. Set the metrics in the operator controller.
Planning to add the following metrics:
 - States completed (per special resource)
 - Number of SpecialResources being managed
 - Kernel version (per node)
 - Other SRO specific runtime information

Also planning to eventually add some alerts, but still thinking about how. 

- We want to alert if stuck on a state for too long (~30 minutes)
- If SRO Operator pod is degraded ( see NTO PrometheusRules)